### PR TITLE
name change p5-deeplearn-js to ml5-js #7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ npm run test
 
 ## ML5 Website
 
-The [ML5 website](https://itpnyu.github.io/p5-deeplearn-js/) is built with [Docusaurus](https://docusaurus.io/).
+The [ML5 website](https://itpnyu.github.io/ml5-js/) is built with [Docusaurus](https://docusaurus.io/).
 
 Docusaurus is an open-source library, built with React, to create and maintain documentation websites.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [p5ML](https://itpnyu.github.io/p5-deeplearn-js/)
+# [p5ML](https://itpnyu.github.io/ml5-js/)
 
 **_This project is currently in development._**
 
@@ -6,11 +6,11 @@ p5ML.js is a high level Javascript library for machine learning. The main idea o
 
 ## Resources
 
-- [Getting Started](https://itpnyu.github.io/p5-deeplearn-js/docs/getting-started.html)
-- [API Reference](https://itpnyu.github.io/p5-deeplearn-js/docs/imagenet.html)
-- [Examples](https://itpnyu.github.io/p5-deeplearn-js/docs/simple-image-classification-example.html)
-- [Learn](https://itpnyu.github.io/p5-deeplearn-js/docs/glossary-statistics.html)
-- [Experiments](https://itpnyu.github.io/p5-deeplearn-js/en/experiments.html)
+- [Getting Started](https://itpnyu.github.io/ml5-js/docs/getting-started.html)
+- [API Reference](https://itpnyu.github.io/ml5-js/docs/imagenet.html)
+- [Examples](https://itpnyu.github.io/ml5-js/docs/simple-image-classification-example.html)
+- [Learn](https://itpnyu.github.io/ml5-js/docs/glossary-statistics.html)
+- [Experiments](https://itpnyu.github.io/ml5-js/en/experiments.html)
 
 ## Contributing
 

--- a/demos/teachableMachine/README.md
+++ b/demos/teachableMachine/README.md
@@ -2,4 +2,4 @@
 
 ![Demo gif](demo.gif)
 
-[Demo](https://itpnyu.github.io/p5-deeplearn-js/demos/teachableMachine/index.html)
+[Demo](https://itpnyu.github.io/ml5-js/demos/teachableMachine/index.html)

--- a/demos/teachableMachine/index.html
+++ b/demos/teachableMachine/index.html
@@ -13,7 +13,7 @@
 <body>
   <div class="body-container row">
     <h1 class="center-text">Teachable Machine</h1>
-    <p class="center-text">This is a recreation of Google's <a href="https://teachablemachine.withgoogle.com">Teachable Machines</a> in <a href="https://github.com/ITPNYU/p5-deeplearn-js">p5-deeplearn-js</a></p>
+    <p class="center-text">This is a recreation of Google's <a href="https://teachablemachine.withgoogle.com">Teachable Machines</a> in <a href="https://github.com/ITPNYU/ml5-js">ml5-js</a></p>
     <div class="input-container white-box col-3">
       <h3 class="title">INPUT</h3>
       <div id="canvasContainer" class="center-container"></div>

--- a/docs/api-Getting-Started.md
+++ b/docs/api-Getting-Started.md
@@ -8,7 +8,7 @@ p5ML.js is heavily inspired by [Processing](https://processing.org/) and [p5.js]
 
 ## Setup
 
-Download the [latest version](https://github.com/ITPNYU/p5-deeplearn-js) of p5ML.js and save the following HTML file to your computer:
+Download the [latest version](https://github.com/ITPNYU/ml5-js) of p5ML.js and save the following HTML file to your computer:
 
 ```html
 <!DOCTYPE html>

--- a/docs/api-Imagenet.md
+++ b/docs/api-Imagenet.md
@@ -67,4 +67,4 @@ let prediction = classifier.predict(img, function(result){
 
 ## Source
 
-[/src/ImageNet/index.js](https://github.com/cvalenzuela/p5-deeplearn-js/blob/master/src/ImageNet/index.js)
+[/src/ImageNet/index.js](https://github.com/cvalenzuela/ml5-js/blob/master/src/ImageNet/index.js)

--- a/docs/api-Knn-Image.md
+++ b/docs/api-Knn-Image.md
@@ -111,4 +111,4 @@ knn.predict(video, callback);
 
 ## Source
 
-[/src/KNNImage/index.js](https://github.com/ITPNYU/p5-deeplearn-js/blob/master/src/KNNImage/index.js)
+[/src/KNNImage/index.js](https://github.com/ITPNYU/ml5-js/blob/master/src/KNNImage/index.js)

--- a/docs/api-LSTM.md
+++ b/docs/api-LSTM.md
@@ -6,7 +6,7 @@ title: LSTM
 [LSTMs](https://colah.github.io/posts/2015-08-Understanding-LSTMs/) (Long Short Term Memory networks) are a kind of Neural Network architecture useful for working with series of data where the order of the series matters. This class allows you run a pre-trained model 
 through inference mode and generate new content. 
 
-You can train your own models [using this tutorial](training-LSTM.md) or used [this set of pretrained models](https://github.com/ITPNYU/p5-deeplearn-js/tree/master/training/lstm)
+You can train your own models [using this tutorial](training-LSTM.md) or used [this set of pretrained models](https://github.com/ITPNYU/ml5-js/tree/master/training/lstm)
 
 ### Example
 
@@ -97,4 +97,4 @@ lstm.generate(options, function(output){
   
 ## Source
 
-[/src/Lstm/index.js](https://github.com/ITPNYU/p5-deeplearn-js/blob/master/src/Lstm/index.js)
+[/src/Lstm/index.js](https://github.com/ITPNYU/ml5-js/blob/master/src/Lstm/index.js)

--- a/docs/api-Neural-Network.md
+++ b/docs/api-Neural-Network.md
@@ -90,4 +90,4 @@ knn.predict(video, callback);
 
 ## Source
 
-[/src/NeuralNetwork/index.js](https://github.com/cvalenzuela/p5-deeplearn-js/blob/master/src/NeuralNetwork/index.js)
+[/src/NeuralNetwork/index.js](https://github.com/cvalenzuela/ml5-js/blob/master/src/NeuralNetwork/index.js)

--- a/docs/api-TransformNet.md
+++ b/docs/api-TransformNet.md
@@ -78,4 +78,4 @@ let outputImgData = fst.predict(img);
 
 ## Source
 
-[/src/Lstm/index.js](https://github.com/ITPNYU/p5-deeplearn-js/tree/master/src/TransformNet)
+[/src/Lstm/index.js](https://github.com/ITPNYU/ml5-js/tree/master/src/TransformNet)

--- a/docs/api-Word2vec.md
+++ b/docs/api-Word2vec.md
@@ -104,4 +104,4 @@ const average = wordVectors.average(['red', 'green'], 1); // Should output yello
 
 ## Source
 
-[/src/Word2vec/index.js](https://github.com/ITPNYU/p5-deeplearn-js/blob/master/src/Word2vec/index.js)
+[/src/Word2vec/index.js](https://github.com/ITPNYU/ml5-js/blob/master/src/Word2vec/index.js)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ITPNYU/p5-deeplearn-js.git"
+    "url": "git+https://github.com/ITPNYU/ml5-js.git"
   },
   "keywords": [
     "machine learning"
@@ -29,9 +29,9 @@
   "author": "NYU ITP <cvalenzuela@nyu.edu> (https://github.com/ITPNYU)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ITPNYU/p5-deeplearn-js/issues"
+    "url": "https://github.com/ITPNYU/ml5-js/issues"
   },
-  "homepage": "https://github.com/ITPNYU/p5-deeplearn-js#readme",
+  "homepage": "https://github.com/ITPNYU/ml5-js#readme",
   "devDependencies": {
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/website/pages/en/experiments.js
+++ b/website/pages/en/experiments.js
@@ -23,7 +23,7 @@ class Help extends React.Component {
         content: "Simple example base on Google's Teachable Machines Project",
         image: siteConfig.baseUrl + "img/teachable.gif",
         title: 'Teachable Machines',
-        imageLink: "https://github.com/ITPNYU/p5-deeplearn-js/tree/master/demos/teachableMachine",
+        imageLink: "https://github.com/ITPNYU/ml5-js/tree/master/demos/teachableMachine",
         imageAlign: "left"
       },
       {

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -2,14 +2,14 @@ const siteConfig = {
   title: 'p5ML.js',
   tagline: 'A high level javascript library for machine learning.',
   url: 'https://itpnyu.github.io',
-  baseUrl: '/p5-deeplearn-js/',
-  projectName: 'p5-deeplearn-js',
+  baseUrl: '/ml5-js/',
+  projectName: 'ml5-js',
   headerLinks: [
     { doc: 'getting-started', label: 'API' },
     { doc: 'simple-image-classification-example', label: 'Examples' },
     { page: 'experiments', label: 'Experiments' },
     { doc: 'glossary-statistics', label: 'Learn' },
-    { href: 'https://github.com/ITPNYU/p5-deeplearn-js', label: 'Code' }
+    { href: 'https://github.com/ITPNYU/ml5-js', label: 'Code' }
   ],
   /* path to images for header/footer */
   headerIcon: '',
@@ -28,12 +28,12 @@ const siteConfig = {
     theme: 'solarized-dark',
   },
   scripts: [
-    'https://rawgit.com/ITPNYU/p5-deeplearn-js/master/dist/p5ml.min.js',
+    'https://rawgit.com/ITPNYU/ml5-js/master/dist/p5ml.min.js',
     'https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.min.js',
     'https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.min.js',
   ],
   // You may provide arbitrary config keys to be used as needed by your template.
-  repoUrl: 'https://github.com/ITPNYU/p5-deeplearn-js',
+  repoUrl: 'https://github.com/ITPNYU/ml5-js',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
This only changes the URL paths. All the actual naming stuff (in terms of the `p5ml` object) still has to be changed, as well as any documentation pages.